### PR TITLE
Make virtual-nascom.html work better on smaller screens

### DIFF
--- a/virtual-nascom.html
+++ b/virtual-nascom.html
@@ -6,25 +6,65 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="viewport" content="viewport-fit=cover, user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1">
   <title>Nascom 2 Simulator</title>
   <style>
+    :root {
+      --font-family:Arial;
+      --font-size:1em;
+      --font-size-input:1em;
+      --container-width:960x;
+      --canvas-width:960px;
+      --canvas-height:512px;
+      --canvas-margin:0px;
+    }
+    @media (max-width: 959px) {
+      :root {
+        --container-width:414px;
+        --canvas-width:480px;
+        --canvas-height:256px;
+        --canvas-margin:-33px;
+      }
+    }
+    @media (max-width: 413px) {
+      :root {
+        --container-width:360px;
+        --canvas-margin:-48px;
+      }
+    }
     html {
       display: table;
       margin: auto;
     }
     body {
       display: table-cell;
-      font-family: Verdana;
-      font-size: 12pt;
+      font-family: var(--font-family);
+      font-size: var(--font-size);
       background: #e0e0e0;
+    }
+    button {
+      font-family:var(--font-family);
+      font-size: var(--font-size-input);
+    }
+    select {
+      font-family:var(--font-family);
+      font-size: var(--font-size-input);
     }
     h1 {
       text-align: center;
     }
+    #container {
+      width: var(--container-width);
+      overflow:hidden;
+    }
     #canvas-container {
       text-align: center;
+      overflow:hidden;
     }
     #canvas {
+      width:var(--canvas-width);
+      height:var(--canvas-height);
+      margin-left:var(--canvas-margin);
       border-radius:10px;
     }
     #controls {
@@ -37,53 +77,76 @@
     }
   </style>
 </head>
-<body onload="init()">
-  <h1>Nascom 2 Simulator</h1>
-  <div id="sub-header">Ported to the Web by: Peter Jensen</div>
-  <div id="canvas-container">
-    <canvas id="canvas" oncontextmenu="event.preventDefault()" width="720" height="384"></canvas>
+<body onload="onLoaded()">
+  <div id="container">
+    <h1>Nascom 2 Simulator</h1>
+    <div id="sub-header">Ported to the Web by: Peter Jensen</div>
+    <div style="width:0px; height:0px; overflow:hidden">
+      <textarea id="text"></textarea>
+    </div>
+    <div id="canvas-container">
+      <canvas id="canvas" oncontextmenu="event.preventDefault()"></canvas>
+    </div>
+    <div id="controls">
+      <button id="reset">Reset</button>
+      <select id="pick">
+        <option>Avalanch.nas</option>
+        <option>BLS-Breakout.nas</option>
+        <option>BLS-Pascal-1.2.nas</option>
+        <option>BLS-Spacezap.nas</option>
+        <option>Hole.nas</option>
+        <option>KKS-3dmaze.nas</option>
+        <option>Monster.nas</option>
+        <option>Reversi.nas</option>
+        <option>Serpent.nas</option>
+        <option>Spcinv.nas</option>
+        <option>galaxian.nas</option>
+        <option>jailbrk.nas</option>
+        <option>pacman.nas</option>
+        <option>pacman2.nas</option>
+        <option>spacewar.nas</option>
+      </select>
+      <button id="load">Load</button>
+      <button id="keyboard">Keyboard</button>
+    </div>
+    <div>
+      <h3>Usage</h3>
+      <ul>
+        <li>Pick the program to load, and click 'Load'</li>
+        <li>Execute the program with the NAS-SYS command 'E1000' (typically)</li>
+      </ul>
+      <h3>Notes</h3>
+      <ul>
+        <li>Adapted from: <A href="https://github.com/tommythorn/virtual-nascom">Tommy Thorn's Simulator</A></li>
+        <li>Built with <A href="https://emscripten.org">Emscripten</A></li>
+        <li>Runs with WebAssembly and Javascript</li>
+      </ul>
+      <h3>TODO</h3>
+      <ul>
+        <li>Figure out how to simulate 'save to tape'.  Maybe use IndexedDb or localStorage</li>
+      </ul>
+    </div>
   </div>
-  <div id="controls">
-    <button id="reset">Reset</button>
-    <select id="pick">
-      <option>Avalanch.nas</option>
-      <option>BLS-Breakout.nas</option>
-      <option>BLS-Pascal-1.2.nas</option>
-      <option>BLS-Spacezap.nas</option>
-      <option>Hole.nas</option>
-      <option>KKS-3dmaze.nas</option>
-      <option>Monster.nas</option>
-      <option>Reversi.nas</option>
-      <option>Serpent.nas</option>
-      <option>Spcinv.nas</option>
-      <option>galaxian.nas</option>
-      <option>jailbrk.nas</option>
-      <option>pacman.nas</option>
-      <option>pacman2.nas</option>
-      <option>spacewar.nas</option>
-    </select>
-    <button id="load">Load</button>
-  </div>
-  <div>
-    <h3>Usage</h3>
-    <ul>
-      <li>Pick the program to load, and click 'Load'</li>
-      <li>Execute the program with the NAS-SYS command 'E1000' (typically)</li>
-    </ul>
-    <h3>Notes</h3>
-    <ul>
-      <li>Adapted from: <A href="https://github.com/tommythorn/virtual-nascom">Tommy Thorn's Simulator</A></li>
-      <li>Built with <A href="https://emscripten.org">Emscripten</A></li>
-      <li>Runs with WebAssembly and Javascript</li>
-    </ul>
-    <h3>TODO</h3>
-    <ul>
-      <li>Figure out how to simulate 'save to tape'.  Maybe use IndexedDb or localStorage</li>
-    </ul>
-  </div>
-  <script type='text/javascript'>
+  <script>
+    // Initialization is done after the DOM has loaded AND the Wasm runtime is initialized.
+    // The order of these two events is depending on network speed, so make no assumption
+    // on which one occurs last.
+    var isRuntimeInitialized = false;
+    var isLoaded             = false;
+    function onInit() {
+      isRuntimeInitialized = true;
+      if (isLoaded)
+        init();
+    }
+    function onLoaded() {
+      isLoaded = true;
+      if (isRuntimeInitialized)
+        init();
+    }
     var Module = {
-      canvas: (function() { return document.getElementById('canvas'); })(),
+      noInitialRun: true, // invoke main manually after document load
+      canvas: null,       // initialized after document is loaded
+      onRuntimeInitialized: onInit,
       print: function(text) {
           if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
           console.log(text);
@@ -94,12 +157,14 @@
       }
     };
   </script>
-  <script src="virtual-nascom.js"></script>
   <script>
     var elems = {
+      canvas: null,
+      text: null,
       reset: null,
       pick: null,
-      load: null
+      load: null,
+      keyboard: null
     };
     function load_nascom_string(str) {
       let ptr = allocate(intArrayFromString(str), ALLOC_NORMAL);
@@ -113,13 +178,74 @@
         .then(response => response.text())
         .then(text => load_nascom_string(text));
     }
-    function init() {
+    function keyboardClick(e) {
+      e.preventDefault();
+      elems.keyboard.blur();
+      elems.text.focus();
+      elems.canvas.scrollIntoView(true);
+    }
+    function setCanvasSize() {
+      const bodyWidth = document.body.clientWidth;
+      const canvasMul = Math.floor(bodyWidth/15);
+      let canvasWidth = canvasMul * 15;
+      let canvasHeight = canvasMul * 8;
+      let marginLeft = 0;
+      if (canvasWidth < 480) {
+        canvasWidth  = 480;
+        canvasHeight = 256;
+        marginLeft = (480 - bodyWidth)/2;
+        marginLeft = marginLeft > 48 ? 48 : marginLeft;
+      }
+      elems.canvas.style.width = canvasWidth + "px";
+      elems.canvas.style.height = canvasHeight + "px";
+      elems.canvas.style.marginLeft = -marginLeft + "px";
+    }
+    function initElems() {
       elems.reset = document.getElementById("reset");
       elems.pick = document.getElementById("pick");
       elems.load = document.getElementById("load");
+      elems.text = document.getElementById("text");
+      elems.canvas = document.getElementById("canvas");
+      elems.keyboard = document.getElementById("keyboard");
+    }
+    function setupKeyboardHandlers() {
+      // this is really only necessary for Android screen keyboards
+      function keyEventHandler(e) {
+        if (e.keyCode == 229) {
+          if (typeof e.custom === "undefined") {
+//            e.stopImmediatePropagation();
+            let oldText = elems.text.value;
+            setTimeout(function () {
+              const keyString = elems.text.value.replace(oldText, '');
+//              alert("keyString = '" + keyString + "', oldText = '" + oldText +"'");
+              if (keyString.length < 1)
+                return;
+              let customEventInit = {custom: true};
+              customEventInit = Object.assign(customEventInit, e);
+              customEventInit.keyCode = keyString.charCodeAt(keyString.length-1);
+              let customKeydown = new KeyboardEvent("keydown", customEventInit);
+              window.dispatchEvent(customKeydown);
+              let customKeyup = new KeyboardEvent("keyup", customEventInit);
+              window.dispatchEvent(customKeyup);
+            }, 0);
+          }
+        }
+      }
+
+      // Setup handler for keydown event
+      window.addEventListener("keydown", keyEventHandler, true);
+    }
+    function init() {
+      initElems();
       elems.load.addEventListener("click", load);
       elems.reset.addEventListener("click", Module._reset_nascom);
+      elems.keyboard.addEventListener("click", keyboardClick);
+      setupKeyboardHandlers();
+      Module.canvas = elems.canvas;
+      //setCanvasSize();
+      Module._main(); // Invoke main from wasm file
     }
   </script>
+  <script src="virtual-nascom.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This PR relates to the discussion in #14
1. Got rid of artifacts in canvas rendering (scaling is 1 for mobile and 2 for desktop)
2. Handle Mobile keyboards (Android is still not perfect)
3. Scroll canvas to top when keyboard is activated

You can check out how it looks here:
   https://peterjensen.github.io/virtual-nascom/virtual-nascom.html

Remember to rebase the gh-pages branch to make it accessible via tommyhorn.github.io